### PR TITLE
persist demo account variable in session storage

### DIFF
--- a/src/client/src/contexts/demo-account-context.tsx
+++ b/src/client/src/contexts/demo-account-context.tsx
@@ -8,17 +8,28 @@ interface DemoAccountContextType {
 }
 
 const DemoAccountContext = createContext<DemoAccountContextType>({
-  isDemoAccount: false,
+  isDemoAccount: true,
 });
 
 export function DemoAccountProvider({ children }: { children: React.ReactNode }) {
   const session = useSession();
-  const [isDemoAccount, setIsDemoAccount] = useState(false);
+  const [isDemoAccount, setIsDemoAccount] = useState(() => {
+    // Initialize from localStorage if available
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('isDemoAccount');
+      return stored ? JSON.parse(stored) : true;
+    }
+    return true;
+  });
 
   useEffect(() => {
     if (session?.data?.user?.email) {
       const isDemo = session.data.user.email.toLowerCase() === "demo@ragworks.ai";
       setIsDemoAccount(isDemo);
+      // Persist to localStorage
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('isDemoAccount', JSON.stringify(isDemo));
+      }
     } else {
       console.log('[DemoAccount Debug] No user email found in session');
     }


### PR DESCRIPTION
This will persist the demoaccount variable. So even after page refresh, you can't see settings and profile icon.