### PR TITLE
Feat/dashboard refinements

### DIFF
--- a/src/client/src/app/(auth)/layout.tsx
+++ b/src/client/src/app/(auth)/layout.tsx
@@ -8,13 +8,11 @@ export default function AuthLayout({
 	children: JSX.Element;
 }) {
 	return (
-		<div className="min-h-screen grid lg:grid-cols-2 bg-white dark:bg-white">
-			<AuthDetailsCarousel />
-			<AuthFormContainer>
-				<AutoSignInDemoInstance demoCreds={{ email: process.env.DEMO_ACCOUNT_EMAIL, password: process.env.DEMO_ACCOUNT_PASSWORD }}>
-					{children}
-				</AutoSignInDemoInstance>
-			</AuthFormContainer>
-		</div>
+		<AutoSignInDemoInstance demoCreds={{ email: process.env.DEMO_ACCOUNT_EMAIL, password: process.env.DEMO_ACCOUNT_PASSWORD }}>
+			<div className="min-h-screen grid lg:grid-cols-2 bg-white dark:bg-white">
+				<AuthDetailsCarousel />
+				<AuthFormContainer>{children}</AuthFormContainer>
+			</div>
+		</AutoSignInDemoInstance>
 	);
 }

--- a/src/client/src/app/(playground)/layout.tsx
+++ b/src/client/src/app/(playground)/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Suspense } from "react";
 import Sidebar from "@/components/(playground)/sidebar";
 import Header from "@/components/(playground)/header";
@@ -7,23 +9,26 @@ import CustomPostHogProvider from "@/components/(playground)/posthog";
 import NavigationEvents from "@/components/common/navigation-events";
 import AppInit from "@/components/common/app-init";
 import NavMenus from "@/components/(playground)/nav-menus";
+import { useDemoAccount } from "@/contexts/demo-account-context";
 
-export default async function PlaygroundLayout({
+export default function PlaygroundLayout({
 	children,
 }: {
 	children: React.ReactNode;
 }) {
 	const telemetryEnabled = process.env.TELEMETRY_ENABLED !== "false";
+	const { isDemoAccount } = useDemoAccount();
 
 	return (
 		<CustomPostHogProvider telemetryEnabled={telemetryEnabled}>
 			<TooltipProvider>
-				<div className="flex h-screen w-full overflow-hidden">
+				<div className={`flex h-screen w-full overflow-hidden ${!isDemoAccount && "pl-10"}`}>
 					<div className="flex flex-col grow w-full">
 						<Header />
-						<main className="flex flex-col grow flex-1 items-start p-4 sm:px-6 overflow-hidden">
-							<NavMenus />
-							<ClickhouseConnectivityWrapper />
+						{!isDemoAccount && <Sidebar />}
+						<main className={`flex flex-col grow flex-1 items-start p-4 sm:px-6 overflow-hidden`}>
+							{isDemoAccount && <NavMenus />}
+							{!isDemoAccount && <ClickhouseConnectivityWrapper />}
 							{children}
 						</main>
 					</div>

--- a/src/client/src/app/(playground)/layout.tsx
+++ b/src/client/src/app/(playground)/layout.tsx
@@ -1,11 +1,12 @@
+import { Suspense } from "react";
 import Sidebar from "@/components/(playground)/sidebar";
 import Header from "@/components/(playground)/header";
-import { Suspense } from "react";
 import ClickhouseConnectivityWrapper from "@/components/(playground)/clickhouse-connectivity-wrapper";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import CustomPostHogProvider from "@/components/(playground)/posthog";
 import NavigationEvents from "@/components/common/navigation-events";
 import AppInit from "@/components/common/app-init";
+import NavMenus from "@/components/(playground)/nav-menus";
 
 export default async function PlaygroundLayout({
 	children,
@@ -17,11 +18,11 @@ export default async function PlaygroundLayout({
 	return (
 		<CustomPostHogProvider telemetryEnabled={telemetryEnabled}>
 			<TooltipProvider>
-				<div className="flex h-screen w-full pl-[56px] overflow-hidden">
-					<Sidebar />
+				<div className="flex h-screen w-full overflow-hidden">
 					<div className="flex flex-col grow w-full">
 						<Header />
 						<main className="flex flex-col grow flex-1 items-start p-4 sm:px-6 overflow-hidden">
+							<NavMenus />
 							<ClickhouseConnectivityWrapper />
 							{children}
 						</main>

--- a/src/client/src/components/(auth)/auto-signin-demo-instance.tsx
+++ b/src/client/src/components/(auth)/auto-signin-demo-instance.tsx
@@ -36,12 +36,8 @@ export default function AutoSignInDemoInstance({ children, demoCreds }: { childr
   }, []);
 
   if (demoCreds.email && demoCreds.password && !err) return (
-    <div className="flex flex-col items-center justify-center space-y-4 text-center">
+    <div className="flex flex-col items-center justify-center h-screen space-y-4 text-center">
       <Loader2 className="h-8 w-8 animate-spin text-primary" />
-      <h2 className="text-2xl font-semibold">Setting Up Demo Account</h2>
-      <p className="text-muted-foreground">
-        Please wait while we prepare a demo account for you. This may take a few moments.
-      </p>
     </div>
   )
 

--- a/src/client/src/components/(playground)/clickhouse-connectivity-wrapper.tsx
+++ b/src/client/src/components/(playground)/clickhouse-connectivity-wrapper.tsx
@@ -1,4 +1,6 @@
 "use client";
+
+import { useDemoAccount } from "@/contexts/demo-account-context";
 import { pingActiveDatabaseConfig } from "@/helpers/client/database-config";
 import { getPingDetails } from "@/selectors/database-config";
 import { useRootStore } from "@/store";
@@ -14,13 +16,15 @@ const ALLOWED_CONNECTIVITY_ALERT = [
 	"/prompt-hub",
 	"/vault",
 ];
-
-export default function ClickhouseConnectivityWrapper() {
+ 
+function ClickhouseConnectivityAlert() {
 	const pingDetails = useRootStore(getPingDetails);
 	const pathname = usePathname();
 
 	useEffect(() => {
-		if (pingDetails.status === "pending") pingActiveDatabaseConfig();
+		if (pingDetails.status === "pending") {
+			pingActiveDatabaseConfig();
+		}
 	}, []);
 
 	if (pingDetails.error && ALLOWED_CONNECTIVITY_ALERT.includes(pathname)) {
@@ -32,8 +36,8 @@ export default function ClickhouseConnectivityWrapper() {
 							Looks like you&apos;ve found the doorway to the great nothing
 						</h3>
 						<div className="mb-2 text-sm">
-							Sorry about that! Please visit settings page to configure your
-							active clickhouse database.
+							Sorry about that! Please visit the settings page to configure your
+							active ClickHouse database.
 						</div>
 						<Link
 							href="/settings/database-config"
@@ -55,4 +59,13 @@ export default function ClickhouseConnectivityWrapper() {
 	}
 
 	return null;
+}
+
+
+export default function ClickhouseConnectivityWrapper() {
+	const { isDemoAccount } = useDemoAccount();
+
+	if (isDemoAccount) return null;
+
+	return <ClickhouseConnectivityAlert />;
 }

--- a/src/client/src/components/(playground)/clickhouse-connectivity-wrapper.tsx
+++ b/src/client/src/components/(playground)/clickhouse-connectivity-wrapper.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { useDemoAccount } from "@/contexts/demo-account-context";
 import { pingActiveDatabaseConfig } from "@/helpers/client/database-config";
 import { getPingDetails } from "@/selectors/database-config";
@@ -16,15 +15,13 @@ const ALLOWED_CONNECTIVITY_ALERT = [
 	"/prompt-hub",
 	"/vault",
 ];
- 
-function ClickhouseConnectivityAlert() {
+
+export default function ClickhouseConnectivityWrapper() {
 	const pingDetails = useRootStore(getPingDetails);
 	const pathname = usePathname();
 
 	useEffect(() => {
-		if (pingDetails.status === "pending") {
-			pingActiveDatabaseConfig();
-		}
+		if (pingDetails.status === "pending") pingActiveDatabaseConfig();
 	}, []);
 
 	if (pingDetails.error && ALLOWED_CONNECTIVITY_ALERT.includes(pathname)) {
@@ -36,8 +33,8 @@ function ClickhouseConnectivityAlert() {
 							Looks like you&apos;ve found the doorway to the great nothing
 						</h3>
 						<div className="mb-2 text-sm">
-							Sorry about that! Please visit the settings page to configure your
-							active ClickHouse database.
+							Sorry about that! Please visit settings page to configure your
+							active clickhouse database.
 						</div>
 						<Link
 							href="/settings/database-config"
@@ -59,13 +56,4 @@ function ClickhouseConnectivityAlert() {
 	}
 
 	return null;
-}
-
-
-export default function ClickhouseConnectivityWrapper() {
-	const { isDemoAccount } = useDemoAccount();
-
-	if (isDemoAccount) return null;
-
-	return <ClickhouseConnectivityAlert />;
 }

--- a/src/client/src/components/(playground)/nav-menus.tsx
+++ b/src/client/src/components/(playground)/nav-menus.tsx
@@ -1,0 +1,71 @@
+"use client";
+import Link from "next/link";
+import { FileJson2, LayoutDashboard } from "lucide-react";
+import { ReactElement } from "react";
+import { usePathname } from "next/navigation";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { buttonVariants } from "@/components/ui/button";
+
+type NavMenuItemProps = {
+    className?: string;
+    icon: ReactElement;
+    text: string;
+    link: string;
+};
+
+const ICON_CLASSES = "flex-shrink-0 size-5";
+
+const NAV_MENU_ITEMS: NavMenuItemProps[] = [
+    {
+        icon: <LayoutDashboard className={ICON_CLASSES} />,
+        text: "Dashboard",
+        link: "/dashboard",
+    },
+    {
+        icon: <FileJson2 className={ICON_CLASSES} />,
+        text: "Requests",
+        link: "/requests",
+    },
+];
+
+const NavMenus = () => {
+    const pathname = usePathname();
+
+    return (
+        <nav className="flex gap-2 pb-4">
+            {NAV_MENU_ITEMS.map((item, index) => {
+                const isActive = pathname.startsWith(item.link ?? "");
+
+                return (
+                    <Tooltip key={`nav-menu-${index}`}>
+                        <TooltipTrigger asChild>
+                            <Link
+                                href={item.link ?? ""}
+                                className={`${buttonVariants({
+                                    variant: "ghost",
+                                    size: "icon",
+                                })} ${isActive
+                                    ? "text-white bg-primary dark:bg-primary dark:text-white"
+                                    : "text-stone-600 dark:text-white"
+                                    } ${item.className || ""}`}
+                                aria-label={item.text}
+                            >
+                                {item.icon}
+                            </Link>
+
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" sideOffset={5}>
+                            {item.text}
+                        </TooltipContent>
+                    </Tooltip>
+                );
+            })}
+        </nav>
+    );
+};
+
+export default NavMenus;

--- a/src/client/src/components/(playground)/sidebar.tsx
+++ b/src/client/src/components/(playground)/sidebar.tsx
@@ -104,12 +104,11 @@ const SidebarItem = (props: SidebarItemProps) => {
 				) : (
 					<a
 						href={props.link}
-						className={`flex items-center p-2 ${
-							props.className || ""
-						} ${buttonVariants({
-							variant: "ghost",
-							size: "icon",
-						})}`}
+						className={`flex items-center p-2 ${props.className || ""
+							} ${buttonVariants({
+								variant: "ghost",
+								size: "icon",
+							})}`}
 						onClick={props.onClick}
 						target={props.target}
 					>
@@ -130,7 +129,7 @@ export default function Sidebar() {
 
 	console.log("[Sidebar Debug] isDemoAccount:", isDemoAccount);
 
-	const filteredSidebarItems = SIDEBAR_ITEMS.filter(item => 
+	const filteredSidebarItems = SIDEBAR_ITEMS.filter(item =>
 		!isDemoAccount || item.text !== "Settings"
 	);
 
@@ -157,11 +156,10 @@ export default function Sidebar() {
 				{filteredSidebarItems.map((item, index) => (
 					<SidebarItem
 						key={`sidebar-top-${index}`}
-						className={`${
-							pathname.startsWith(item.link || "")
+						className={`${pathname.startsWith(item.link || "")
 								? "text-white bg-primary dark:bg-primary dark:text-white"
 								: "text-stone-600 dark:text-white"
-						}`}
+							}`}
 						{...item}
 					/>
 				))}
@@ -170,11 +168,10 @@ export default function Sidebar() {
 				{SIDEBAR_BOTTOM_ITEMS.map((item, index) => (
 					<SidebarItem
 						key={`sidebar-bottom-${index}`}
-						className={`${
-							pathname.startsWith(item.link || "")
+						className={`${pathname.startsWith(item.link || "")
 								? "text-white bg-primary dark:bg-primary dark:text-white"
 								: "text-stone-600 dark:text-white"
-						}`}
+							}`}
 						{...item}
 					/>
 				))}

--- a/src/client/src/components/common/app-init.tsx
+++ b/src/client/src/components/common/app-init.tsx
@@ -11,5 +11,19 @@ export default function AppInit() {
 		if (!isFetched) fetchAndPopulateCurrentUserStore();
 	}, [isFetched]);
 
+	// Top-level effect: set pingStatus for demo accounts
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			const isDemo = localStorage.getItem('isDemoAccount') === 'true';
+			if (isDemo) {
+				const currentStatus = useRootStore.getState().databaseConfig.ping.status;
+				if (currentStatus !== 'success') {
+					useRootStore.getState().databaseConfig.setPing({ status: 'success' });
+					console.log('[AppInit Debug] Patched pingStatus to success for demo account (top-level effect)');
+				}
+			}
+		}
+	}, []);
+
 	return null;
 }


### PR DESCRIPTION
https://www.loom.com/share/504e26dc5ba54866998d83c4d12786bc?sid=738d3b94-860f-4476-a753-1d610878ca68

Implements a new custom navbar specifically for the demo-account.
Summary by Sourcery
Add first-class demo account support by introducing a context and provider, tailoring the UI and navigation for demo users, updating seed data and configurations, and refining build scripts accordingly.

New Features:

Add DemoAccountContext and provider to detect and persist demo account status
Introduce NavMenus component for demo accounts with Dashboard and Requests navigation
Enhancements:

Hide header user menu and filter sidebar items for demo accounts
Adjust PlaygroundLayout to toggle between full sidebar and nav menus with updated padding
Wrap root application layout with SessionProvider and DemoAccountProvider
Update Prisma seed script to upsert a demo user and database config using bcrypt-hashed credentials
Build:

Simplify Docker Compose by hardcoding DB credentials, remapping ports to 3002, and disabling telemetry for the Otel collector
Refine entrypoint script to use NEXTAUTH_URL and comment out random secret generation
Add bcrypt dependency for password hashing